### PR TITLE
fix broken "Jobs" link

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The best way to interact with the Flashbots community is through our [forum](htt
 
 ### Join us!
 We are not your typical project, we are fully remote and our principles are based on that of a [pirate hacker collective](https://www.youtube.com/watch?v=T0fAznO1wA8). If you are a self-directed individual who puts collective success above your own and is motivated by solving challenging problems with asymmetric impact, you will fit right in. 
-* [**Open job positions**](https://boards.greenhouse.io/flashbots): Check out the list of full-time roles we're actively recruiting for.
+* [**Open job positions**](https://www.flashbots.net/jobs): Check out the list of full-time roles we're actively recruiting for.
 * [**MEV research fellowship**](https://github.com/flashbots/mev-research/blob/main/grants.md):  We issue research grants to Flashbots Research Proposal submitters. 
 * For anything else, please reach out to us at [jobs@flashbots.net](mailto:jobs@flashbots.net)!
 
@@ -36,7 +36,7 @@ We are not your typical project, we are fully remote and our principles are base
 * ⚡ MEV-Boost: https://boost.flashbots.net
 * 🗓️ Calendar: https://calendar.flashbots.net
 * 🤍 Whitehat: https://whitehat.flashbots.net
-* 🛠️ Join us: https://boards.greenhouse.io/flashbots
+* 🛠️ Join us: https://www.flashbots.net/jobs
 * 💭 New to MEV?: https://docs.flashbots.net/new-to-mev
 * 🎛️ Flashbots Dashboard https://transparency.flashbots.net/
 * 🎯 Our Mission: https://writings.flashbots.net/writings/frontrunning-mev-crisis


### PR DESCRIPTION
The current "jobs" link directs to (https://boards.greenhouse.io/flashbots) which no longer is active.
Changed to (https://www.flashbots.net/jobs).